### PR TITLE
Add NotFair - open-source SEO & paid-ads agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Whether you're a developer, designer, marketer, or content creator, we help you 
 |-----------|---------------|-------------------|-----------|
 | Localo | • Local SEO optimization<br>• Business profile management<br>• Review tracking | • Business Owners<br>• Digital Marketers<br>• SEO Specialists | [View Tool](http://www.tooljunction.io/ai-tools/localo) |
 | Kendal | • Social media content<br>• Image creation<br>• Post management | • Social Media Managers<br>• Digital Marketers<br>• Content Creators | [View Tool](http://www.tooljunction.io/ai-tools/kendal) |
+| NotFair | • SEO site analysis & keyword research<br>• Google Ads & Meta Ads management<br>• GEO optimization & schema markup | • SEO Specialists<br>• Digital Marketers<br>• Paid Ads Managers | [View Tool](https://github.com/nowork-studio/NotFair) |
 
 ## Productivity & Automation
 


### PR DESCRIPTION
Hi, thanks for maintaining this directory — it's a great resource for discovering AI tools.

I'd like to suggest adding **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code agent skills for marketing work. It has ~2.9k stars on GitHub and is MIT-licensed.

NotFair covers three main areas:
- **SEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword & bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so the agent skills work with real account data rather than just generating static copy.

I've added it to the **Marketing & SEO** section, which seemed like the best fit. Happy to reword, move it to a different section, or trim the description if you'd prefer a different format.

Thanks!